### PR TITLE
Mark email, password, userid to be redacted

### DIFF
--- a/beetsplug/follow.py
+++ b/beetsplug/follow.py
@@ -122,6 +122,10 @@ class FollowPlugin(BeetsPlugin):
 
         self.config.add({'auto': False})
 
+        self.config['email'].redact = True
+        self.config['password'].redact = True
+        self.config['userid'].redact = True
+
         if self.config['auto']:
             self.register_listener('album_imported', follow_added_artist)
             self.register_listener('item_removed', track_removed_artists)


### PR DESCRIPTION
Since version 1.3.11 beets allows plugin fields to be marked as redacted, such that sensitive information is not printed as clear text when dumping config (i.e., during `$ beet config`).

With this update the config will be printed as:

```
follow:
    auto: yes
    email: REDACTED
    password: REDACTED
    userid: REDACTED
```

See http://beets.readthedocs.org/en/latest/changelog.html and http://beets.readthedocs.org/en/latest/dev/plugins.html
